### PR TITLE
Fix root_path config problem (#24)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -706,18 +706,18 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fastapi"
-version = "0.108.0"
+version = "0.109.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fastapi-0.108.0-py3-none-any.whl", hash = "sha256:8c7bc6d315da963ee4cdb605557827071a9a7f95aeb8fcdd3bde48cdc8764dd7"},
-    {file = "fastapi-0.108.0.tar.gz", hash = "sha256:5056e504ac6395bf68493d71fcfc5352fdbd5fda6f88c21f6420d80d81163296"},
+    {file = "fastapi-0.109.0-py3-none-any.whl", hash = "sha256:8c77515984cd8e8cfeb58364f8cc7a28f0692088475e2614f7bf03275eba9093"},
+    {file = "fastapi-0.109.0.tar.gz", hash = "sha256:b978095b9ee01a5cf49b19f4bc1ac9b8ca83aa076e770ef8fd9af09a2b88d191"},
 ]
 
 [package.dependencies]
 pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.29.0,<0.33.0"
+starlette = ">=0.35.0,<0.36.0"
 typing-extensions = ">=4.8.0"
 
 [package.extras]
@@ -2760,13 +2760,13 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "starlette"
-version = "0.32.0.post1"
+version = "0.35.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "starlette-0.32.0.post1-py3-none-any.whl", hash = "sha256:cd0cb10ddb49313f609cedfac62c8c12e56c7314b66d89bb077ba228bada1b09"},
-    {file = "starlette-0.32.0.post1.tar.gz", hash = "sha256:e54e2b7e2fb06dff9eac40133583f10dfa05913f5a85bf26f427c7a40a9a3d02"},
+    {file = "starlette-0.35.1-py3-none-any.whl", hash = "sha256:50bbbda9baa098e361f398fda0928062abbaf1f54f4fadcbe17c092a01eb9a25"},
+    {file = "starlette-0.35.1.tar.gz", hash = "sha256:3e2639dac3520e4f58734ed22553f950d3f3cb1001cd2eaac4d57e8cdc5f66bc"},
 ]
 
 [package.dependencies]
@@ -3028,4 +3028,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "12c0aebed8f33afdb20552b2f14460a841579766899952b5680b54c8e6f55135"
+content-hash = "857bcb164811206de42bd99ee55a501a9d8ae9273ea92292303df87222f5bfc7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blacklist"
-version = "1.4.0"
+version = "1.5.0"
 description = ""
 authors = ["Dmitriev Andrey <justkeepwalking@yandex.ru>"]
 readme = "README.md"
@@ -8,7 +8,7 @@ packages = [{include = "src"}]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.12"
-fastapi = "^0.108.0"
+fastapi = "^0.109.0"
 flake8 = "^7.0.0"
 mypy = "^1.7.1"
 isort = "^5.12.0"

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from src.api.history_router import api_router as history_router
 from src.api.ping_router import api_router as ping_router
 from src.api.whitelist_router import api_router as whitelist_router
 from src.core.config import app_settings
+from version import get_version
 
 app_configs: dict[str, Any] = dict(
     {
@@ -19,11 +20,13 @@ app_configs: dict[str, Any] = dict(
         'title': app_settings.app_title,
         # Rust based JSON serializer
         'default_response_class': ORJSONResponse,
-        # root path for proxy serving adoptions (https://fastapi.tiangolo.com/advanced/behind-a-proxy/)
-        'root_path': app_settings.root_path,
+        'version': get_version(),
     }
 )
 
+if app_settings.root_path and app_settings.root_path != '/':
+    # root path for proxy serving adoptions (https://fastapi.tiangolo.com/advanced/behind-a-proxy/)
+    app_configs['root_path'] = app_settings.root_path
 
 # Show OpenAPI interface if allowed
 if app_settings.show_openapi:
@@ -32,7 +35,6 @@ if app_settings.show_openapi:
     # OpenAPI docs address OpenAPI
     app_configs['openapi_url'] = '/api/openapi.json'
 
-app_configs['debug'] = True
 app = FastAPI(**app_configs)
 app.include_router(banned_ip_router, prefix='/addresses/banned')
 app.include_router(allowed_ip_router, prefix='/addresses/allowed')
@@ -50,5 +52,4 @@ if __name__ == '__main__':
     LOGGING_CONFIG['formatters']['access'][
         'fmt'
     ] = '%(asctime)s %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-
     uvicorn.run('main:app', host=app_settings.host, port=app_settings.port, reload=True)

--- a/version.py
+++ b/version.py
@@ -9,7 +9,7 @@ class Version:
 
 
 # Change application version here
-VERSION = {'major': 1, 'minor': 4, 'patch': 0}
+VERSION = {'major': 1, 'minor': 5, 'patch': 0}
 
 VERSION_INFO = Version(**VERSION)
 


### PR DESCRIPTION
If ROOT_PATH=/ in .env file we should not set '/' to FastAPI class 'root_path' __init__ parameter
